### PR TITLE
Added support for command translation

### DIFF
--- a/src/main/java/mypermissions/api/command/CommandManager.java
+++ b/src/main/java/mypermissions/api/command/CommandManager.java
@@ -98,7 +98,7 @@ public class CommandManager {
 
     public static String getPermForCommand(String commandName) {
         for(CommandTree tree : commandTrees) {
-            if(tree.getRoot().getAnnotation().name().equals(commandName)) {
+            if(tree.getRoot().getLocalizedName().equals(commandName)) {
                 return tree.getRoot().getAnnotation().permission();
             }
         }

--- a/src/main/java/mypermissions/command/CommandModel.java
+++ b/src/main/java/mypermissions/command/CommandModel.java
@@ -26,16 +26,16 @@ public class CommandModel extends CommandBase implements PermissionObject {
 
     @Override
     public List getCommandAliases() {
-        return Arrays.asList(commandTree.getRoot().getAnnotation().alias());
+        return Arrays.asList(commandTree.getRoot().getLocalizedAlias());
     }
 
     @Override
     public String getCommandName() {
-        return commandTree.getRoot().getAnnotation().name();
+        return commandTree.getRoot().getLocalizedName();
     }
 
     public String getCommandUsage(ICommandSender sender) {
-        return commandTree.getRoot().getAnnotation().syntax();
+        return commandTree.getRoot().getLocalizedSyntax();
     }
 
     /**


### PR DESCRIPTION
Command name, syntax and aliases can be translated by the following syntax:

```
command.mytown.plot.sell.name=sell
command.mytown.plot.sell.syntax=/town plot sell <price>
command.mytown.plot.sell.alias=start-selling,sell2,sell-this-plot
```

The default value present on the annotation is used when the translation key is absent.
